### PR TITLE
feat(ui): show model and thinking level in /team list, /team status, and member_status tool

### DIFF
--- a/extensions/teams/leader-info-commands.ts
+++ b/extensions/teams/leader-info-commands.ts
@@ -5,7 +5,7 @@ import type { TeammateRpc } from "./teammate-rpc.js";
 import type { TeamConfig, TeamMember } from "./team-config.js";
 import type { TeamsStyle } from "./teams-style.js";
 import { formatMemberDisplayName, getTeamsStrings } from "./teams-style.js";
-import { resolveDisplayStatus, formatElapsed, formatTokens, lastMessageSummary, toolActivity } from "./teams-ui-shared.js";
+import { resolveDisplayStatus, formatElapsed, formatTokens, getMemberModel, getMemberThinking, lastMessageSummary, shortModelLabel, toolActivity } from "./teams-ui-shared.js";
 import type { ActivityTracker } from "./activity-tracker.js";
 import { listTasks } from "./task-store.js";
 
@@ -50,7 +50,13 @@ export async function handleTeamListCommand(opts: {
 		const tool = toolActivity(activity.currentToolName);
 		const elapsedTag = elapsed ? ` ${elapsed}` : "";
 		const toolTag = tool ? ` (${tool})` : "";
-		lines.push(`${formatMemberDisplayName(style, name)}: ${displayStatus}${elapsedTag}${toolTag} [${kind}]`);
+		const memberModel = getMemberModel(cfg);
+		const memberThinking = getMemberThinking(cfg);
+		const badges: string[] = [];
+		if (memberModel) badges.push(shortModelLabel(memberModel));
+		if (memberThinking && memberThinking !== "off") badges.push(`t:${memberThinking}`);
+		const badgeTag = badges.length > 0 ? `  ${badges.join("/")}` : "";
+		lines.push(`${formatMemberDisplayName(style, name)}: ${displayStatus}${elapsedTag}${badgeTag}${toolTag} [${kind}]`);
 	}
 
 	ctx.ui.notify(lines.join("\n"), "info");
@@ -195,7 +201,13 @@ export async function handleTeamStatusCommand(opts: {
 			const tool = toolActivity(activity.currentToolName);
 			const toolTag = tool ? ` (${tool})` : "";
 			const stalledTag = displayStatus === "stalled" ? " ⚠ STALLED" : "";
-			lines.push(`${formatMemberDisplayName(style, n)}: ${displayStatus} ${elapsed}${toolTag} · ${formatTokens(activity.totalTokens)} tokens${stalledTag}`);
+			const memberModel = getMemberModel(cfg);
+			const memberThinking = getMemberThinking(cfg);
+			const badges: string[] = [];
+			if (memberModel) badges.push(shortModelLabel(memberModel));
+			if (memberThinking && memberThinking !== "off") badges.push(`t:${memberThinking}`);
+			const badgeTag = badges.length > 0 ? ` · ${badges.join("/")}` : "";
+			lines.push(`${formatMemberDisplayName(style, n)}: ${displayStatus} ${elapsed}${badgeTag}${toolTag} · ${formatTokens(activity.totalTokens)} tokens${stalledTag}`);
 		}
 		ctx.ui.notify(lines.join("\n"), "info");
 		return;
@@ -219,7 +231,8 @@ export async function handleTeamStatusCommand(opts: {
 	const allTasks = await listTasks(teamDir, effectiveTlId);
 	const owned = allTasks.filter((t) => t.owner === name);
 	const activeTask = owned.find((t) => t.status === "in_progress");
-	const model = memberCfg?.meta?.["model"];
+	const memberModel = getMemberModel(memberCfg);
+	const memberThinking = getMemberThinking(memberCfg);
 	const cwd = memberCfg?.cwd;
 
 	const lines: string[] = [
@@ -229,7 +242,8 @@ export async function handleTeamStatusCommand(opts: {
 		`current activity: ${currentTool || "(none)"}`,
 		`tool calls: ${activity.toolUseCount} · turns: ${activity.turnCount} · tokens: ${formatTokens(activity.totalTokens)}`,
 	];
-	if (typeof model === "string" && model) lines.push(`model: ${model}`);
+	if (memberModel) lines.push(`model: ${memberModel}`);
+	if (memberThinking) lines.push(`thinking: ${memberThinking}`);
 	if (cwd) lines.push(`cwd: ${cwd}`);
 	if (activeTask) lines.push(`active task: #${activeTask.id} ${activeTask.subject}`);
 	lines.push(`tasks: ${owned.filter((t) => t.status === "pending").length} pending · ${owned.filter((t) => t.status === "in_progress").length} in-progress · ${owned.filter((t) => t.status === "completed").length} completed`);

--- a/extensions/teams/leader-teams-tool.ts
+++ b/extensions/teams/leader-teams-tool.ts
@@ -589,8 +589,10 @@ export function registerTeamsTool(opts: {
 						const currentTool = toolActivity(activity.currentToolName);
 						const msgPreview = lastMessageSummary(rpc, 80);
 						const model = memberCfg?.meta?.["model"];
+						const thinkingLevel = memberCfg?.meta?.["thinkingLevel"];
 
-						lines.push(`${formatMemberDisplayName(style, n)}: ${displayStatus} ${elapsed}${currentTool ? ` (${currentTool})` : ""} · ${formatTokens(activity.totalTokens)} tokens`);
+						const modelBadge = typeof model === "string" && model ? ` · ${model}` : "";
+						lines.push(`${formatMemberDisplayName(style, n)}: ${displayStatus} ${elapsed}${modelBadge}${currentTool ? ` (${currentTool})` : ""} · ${formatTokens(activity.totalTokens)} tokens`);
 						if (msgPreview) lines.push(`  last: ${msgPreview}`);
 
 						workers.push({
@@ -604,6 +606,7 @@ export function registerTeamsTool(opts: {
 							turnCount: activity.turnCount,
 							totalTokens: activity.totalTokens,
 							model: typeof model === "string" ? model : undefined,
+							thinking: typeof thinkingLevel === "string" ? thinkingLevel : undefined,
 						});
 					}
 
@@ -634,6 +637,7 @@ export function registerTeamsTool(opts: {
 				const owned = allTasks.filter((t) => t.owner === name);
 				const activeTask = owned.find((t) => t.status === "in_progress");
 				const model = memberCfg?.meta?.["model"];
+				const thinkingLevel = memberCfg?.meta?.["thinkingLevel"];
 				const cwd = memberCfg?.cwd;
 
 				const lines: string[] = [
@@ -644,6 +648,7 @@ export function registerTeamsTool(opts: {
 					`tool calls: ${activity.toolUseCount} · turns: ${activity.turnCount} · tokens: ${formatTokens(activity.totalTokens)}`,
 				];
 				if (typeof model === "string" && model) lines.push(`model: ${model}`);
+				if (typeof thinkingLevel === "string" && thinkingLevel) lines.push(`thinking: ${thinkingLevel}`);
 				if (cwd) lines.push(`cwd: ${cwd}`);
 				if (activeTask) lines.push(`active task: #${activeTask.id} ${activeTask.subject}`);
 				lines.push(`tasks: ${owned.filter((t) => t.status === "pending").length} pending · ${owned.filter((t) => t.status === "in_progress").length} in-progress · ${owned.filter((t) => t.status === "completed").length} completed`);
@@ -667,6 +672,7 @@ export function registerTeamsTool(opts: {
 						turnCount: activity.turnCount,
 						totalTokens: activity.totalTokens,
 						model: typeof model === "string" ? model : undefined,
+						thinking: typeof thinkingLevel === "string" ? thinkingLevel : undefined,
 						activeTaskId: activeTask?.id,
 						tasks: {
 							pending: owned.filter((t) => t.status === "pending").length,


### PR DESCRIPTION
## Summary

Surfaces model and thinking level in the remaining UI surfaces where they were missing:

### Changes

| Surface | Before | After |
|---|---|---|
| `/team list` | `researcher: streaming 3m (editing…) [rpc]` | `researcher: streaming 3m  claude-opus-4-6/t:xhigh (editing…) [rpc]` |
| `/team status` (summary) | `researcher: streaming 3m (editing…) · 12.5k tokens` | `researcher: streaming 3m · claude-opus-4-6/t:xhigh (editing…) · 12.5k tokens` |
| `/team status <name>` | `model: anthropic/claude-opus-4-6-20250514` | + `thinking: xhigh` |
| `teams({ action: "member_status" })` summary | name, status, elapsed, tokens | + model badge in text line |
| `teams({ action: "member_status", name })` | model in text + details | + thinking in text + details |

### Files changed

- `extensions/teams/leader-info-commands.ts` — `/team list` and `/team status` commands
- `extensions/teams/leader-teams-tool.ts` — `member_status` tool action (summary + detail)

### Agent-friendly design notes

- Uses existing `getMemberModel()`, `getMemberThinking()`, `shortModelLabel()` helpers from `teams-ui-shared.ts` — no new abstractions
- Compact badge format (`model/t:level`) keeps token cost low in tool responses
- Thinking level included in structured `details` object for programmatic consumption

Closes SYM-40
